### PR TITLE
Add flag to disable using getModifiedAccounts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,14 +9,15 @@ import (
 )
 
 type ZConfiguration struct {
-	Stage       Stage
-	ConfigFile  string
-	EthNode     string // the main eth node
-	RinkebyNode string // Rinkeby network, used for tests
-	LogsPath    string
-	LogsFile    string
-	Database    ZoroDB
-	BlocksDelay int
+	Stage             Stage
+	ConfigFile        string
+	EthNode           string // the main eth node
+	RinkebyNode       string // Rinkeby network, used for tests
+	LogsPath          string
+	LogsFile          string
+	Database          ZoroDB
+	BlocksDelay       int
+	UseGetModAccounts bool
 }
 
 type ZoroDB struct {
@@ -105,7 +106,6 @@ func Load() *ZConfiguration {
 	}
 
 	// Rinkeby node is only required for tests
-
 	zconfig.RinkebyNode = os.Getenv(rinkebyNode)
 	if zconfig.Stage == TEST && zconfig.EthNode == "" {
 		log.Error("no Rinkeby node set in local env ", rinkebyNode)

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 	go matcher.TxMatcher(txBlocksChan, matchesChan, &psqlClient)
 
 	// Watch a Contract
-	go matcher.ContractMatcher(cnBlocksChan, matchesChan, matcher.GetModifiedAccounts, &psqlClient, ethClient)
+	go matcher.ContractMatcher(cnBlocksChan, matchesChan, matcher.GetModifiedAccounts, &psqlClient, ethClient, config.Zconf.UseGetModAccounts)
 
 	// Watch an Event
 	go matcher.EventMatcher(evBlocksChan, matchesChan, &psqlClient, ethClient)

--- a/matcher/contracts_test.go
+++ b/matcher/contracts_test.go
@@ -64,7 +64,8 @@ func TestMatchContractsForBlock(t *testing.T) {
 		"0x",
 		mockGetModAccounts,
 		mockDB{},
-		config.CliMain)
+		config.CliMain,
+		true)
 
 	assert.Equal(t, 1, len(cnMatches))
 	assert.Equal(t, lastBlock, cnMatches[0].BlockNumber)
@@ -85,12 +86,35 @@ func TestMatchContractsForBlockWithBrokenGetModAccount(t *testing.T) {
 		"0x",
 		mockGetModAccounts,
 		mockDB{},
-		config.CliMain)
+		config.CliMain,
+		true)
 
 	assert.Equal(t, 1, len(cnMatches))
 	assert.Equal(t, lastBlock, cnMatches[0].BlockNumber)
 }
 
+func TestMatchContractsForBlockWithModAccountDisabled(t *testing.T) {
+
+	// mocks getModAccount to return empty set; but since the
+	// useGetModAccounts flag is set to false, we want to see one match anyway
+	mockGetModAccounts := func(a, b int, node string) ([]string, error) {
+		return []string{}, nil
+	}
+	lastBlock, err := config.CliMain.EthBlockNumber()
+	assert.NoError(t, err)
+
+	cnMatches := matchContractsForBlock(
+		lastBlock,
+		1554828248,
+		"0x",
+		mockGetModAccounts,
+		mockDB{},
+		config.CliMain,
+		false)
+
+	assert.Equal(t, 1, len(cnMatches))
+	assert.Equal(t, lastBlock, cnMatches[0].BlockNumber)
+}
 func TestMatchContractsWithRealDB(t *testing.T) {
 
 	// clear up the database
@@ -131,7 +155,8 @@ func TestMatchContractsWithRealDB(t *testing.T) {
 		"0x",
 		mockGetModAccounts,
 		&psqlClient,
-		config.CliMain)
+		config.CliMain,
+		true)
 
 	assert.Equal(t, 1, len(cnMatches))
 
@@ -153,7 +178,8 @@ func TestMatchContractsWithRealDB(t *testing.T) {
 		"0x",
 		mockGetModAccounts,
 		&psqlClient,
-		config.CliMain)
+		config.CliMain,
+		true)
 
 	assert.Equal(t, 0, len(cnMatches))
 


### PR DESCRIPTION
Turns out `getModifiedAccounts` is giving us a lot of headaches, so this introduces a flag to switch its use on and off.